### PR TITLE
Fix out of bounds index error for generative PCNs and improve jupyter module imports

### DIFF
--- a/PRECO/PCG.py
+++ b/PRECO/PCG.py
@@ -159,7 +159,7 @@ class PCgraph(PCmodel):
 
         return self.x[:,-self.structure.shape[2]:] 
 
-    def test_iterative(self, X_batch, diagnostics=None, early_stop=False):
+    def test_iterative(self, X_batch):
         X_batch = to_vector(X_batch)     # makes e.g. 28*28 -> 784
 
         self.reset_nodes(batch_size=X_batch.shape[0])
@@ -167,7 +167,7 @@ class PCgraph(PCmodel):
         self.init_hidden()
         self.init_output()
 
-        self.update_xs(train=False, diagnostics=diagnostics, early_stop=early_stop)
+        self.update_xs(train=False)
         return self.x[:,-self.structure.shape[2]:] 
 
     def get_weights(self):

--- a/PRECO/PCN.py
+++ b/PRECO/PCN.py
@@ -61,21 +61,23 @@ class PCnet(PCmodel):
 
 
     def _reset_params(self):
-        self.w, self.b = [], []
+        self.w = [torch.empty(0, 0, device=DEVICE) for _ in range(self.L + 1)]
+        self.b = [torch.empty(0, device=DEVICE) for _ in range(self.L + 1)]
+
         for l in self.weight_layers:
-            in_size = self.structure.layers[l] if self.structure.upward else self.structure.layers[l+1]
-            out_size = self.structure.layers[l+1] if self.structure.upward else self.structure.layers[l]
-            
-            self.w.append(torch.empty( in_size, out_size, device=DEVICE))  
+            if self.structure.upward:
+                in_size = self.structure.layers[l]
+                out_size = self.structure.layers[l + 1]
+            else:
+                in_size = self.structure.layers[l]
+                out_size = self.structure.layers[l - 1]
+
+            self.w[l] = torch.empty(in_size, out_size, device=DEVICE)
             self.weight_init(self.w[l])
 
             if self.structure.use_bias:
-                self.b.append(torch.empty( out_size, device=DEVICE))
+                self.b[l] = torch.empty(out_size, device=DEVICE)
                 self.bias_init(self.b[l])
-       
-        k = self.L if self.structure.upward else 0  # up convention: w0, w1, w2; down convention: w1, w2, w3
-        self.w.insert(k, torch.empty(0,0, device=DEVICE)) 
-        self.b.insert(k, torch.empty(0, device=DEVICE))
                 
         self.no_weigths = sum([wl.shape[0]*wl.shape[1] for wl in self.w])
         if self.structure.use_bias:

--- a/example_notebooks/PCG_MNIST.ipynb
+++ b/example_notebooks/PCG_MNIST.ipynb
@@ -22,8 +22,11 @@
     }
    ],
    "source": [
+    "import os\n",
     "import sys\n",
-    "sys.path.append('/Users/6884407/PRECO')\n",
+    "module_path = os.path.abspath(os.path.join('..'))\n",
+    "if module_path not in sys.path:\n",
+    "    sys.path.append(module_path)\n",
     "\n",
     "from PRECO.utils import *\n",
     "import PRECO.optim as optim\n",

--- a/example_notebooks/PCN_MNIST.ipynb
+++ b/example_notebooks/PCN_MNIST.ipynb
@@ -22,8 +22,11 @@
     }
    ],
    "source": [
+    "import os\n",
     "import sys\n",
-    "sys.path.append('/Users/6884407/PRECO')\n",
+    "module_path = os.path.abspath(os.path.join('..'))\n",
+    "if module_path not in sys.path:\n",
+    "    sys.path.append(module_path)\n",
     "\n",
     "from PRECO.utils import *\n",
     "import PRECO.optim as optim\n",


### PR DESCRIPTION
Hey! Recently I stumbled upon the repo and I saw there was an Out of Bounds index error as reported by https://github.com/bjornvz/PRECO/issues/1

This PR aims to fix that alongside some minor improvements such as:
* removing unused variables from methods `test_iterative` and `update_xs`. (update_xs does not accept params besides train)
* Changed how modules were being loaded to jupyter so we avoid hardcoding the module's PATH.